### PR TITLE
Initial project setup with venv ignored and requirements.txt added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 protrackenv/
 #Byte-compiled / optimized / DLL files
 __pycache__/
+#Git directory
+.git/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This application motivates users by giving them clear visual feedback and enable
 |------------|----------------|-------------------|
 | 23718161   | Tiselle Rayawang    | TiselleWang       |
 | 24215747   | Trisha Santillan     | ToriCodie          |
-| 23802553   | Kai Fletcher  |         |
+| 23808253   | Kai Fletcher  |         |
 | 23236855   | Ruben ho Ho	  |  Rbho10       |
 
 TODO: 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+blinker==1.9.0
+click==8.1.8
+Flask==3.1.0
+itsdangerous==2.2.0
+Jinja2==3.1.6
+MarkupSafe==3.0.2
+SQLAlchemy==2.0.40
+typing_extensions==4.13.2
+Werkzeug==3.1.3


### PR DESCRIPTION
Peer review has been approved. Merging now to main branch. Requirements.txt has been added to correctly import the configured virtual environment used according to the project's requirements guidelines.

To reproduce:
1. Create and activate a virtual environment: `python3 -m venv protrackenv` 
On Mac: `source protrackenv/bin/activate` On Windows: `protrackenv\Scripts\activate`
2. Install the dependencies: `pip install -r requirements.txt`
3. Run the application: `flask run`